### PR TITLE
Fix: No relation attribute selected

### DIFF
--- a/server/services/content-types.js
+++ b/server/services/content-types.js
@@ -50,11 +50,11 @@ const getSelectedRelations = ({ schema, relations }) => {
   return relations
     .filter((relation) => relation in schema)
     .reduce((acc, relation) => {
-    acc[relation] = {
-      select: Object.keys(schema[relation]).map((key) => key)
-    }
-    return acc
-  }, {})
+      acc[relation] = {
+        select: Object.keys(schema[relation]).map((key) => key)
+      }
+      return acc
+    }, {})
 }
 const getSelectedFieldsConfigObj = (schema) =>
   Object.entries(schema).reduce((acc, [key, value]) => (typeof value === 'object' ? acc : [...acc, key]), ['id'])

--- a/server/services/content-types.js
+++ b/server/services/content-types.js
@@ -47,15 +47,17 @@ const shouldAttributeBeIncluded = (attribute, includedRelations) => {
 }
 
 const getSelectedRelations = ({ schema, relations }) => {
-  return relations
-    .filter((relation) => relation in schema)
-    .reduce((acc, relation) => {
+  return relations.reduce((acc, relation) => {
+    if (relation in schema) {
       acc[relation] = {
         select: Object.keys(schema[relation]).map((key) => key)
       }
-      return acc
-    }, {})
+    }
+
+    return acc
+  }, {})
 }
+
 const getSelectedFieldsConfigObj = (schema) =>
   Object.entries(schema).reduce((acc, [key, value]) => (typeof value === 'object' ? acc : [...acc, key]), ['id'])
 

--- a/server/services/content-types.js
+++ b/server/services/content-types.js
@@ -47,7 +47,9 @@ const shouldAttributeBeIncluded = (attribute, includedRelations) => {
 }
 
 const getSelectedRelations = ({ schema, relations }) => {
-  return relations.reduce((acc, relation) => {
+  return relations
+    .filter((relation) => relation in schema)
+    .reduce((acc, relation) => {
     acc[relation] = {
       select: Object.keys(schema[relation]).map((key) => key)
     }


### PR DESCRIPTION
Hey, I found a small bug on collection editing. If you select a relation (one or more) but then don't select any attributes of the relation, the code throws the following error:

```
/Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/content-types.js:54
      select: Object.keys(schema[relation]).map((key) => key)
                     ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/content-types.js:54:22
    at Array.reduce (<anonymous>)
    at getSelectedRelations (/Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/content-types.js:52:6)
    at Object.getEntries (/Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/content-types.js:83:33)
    at OramaManager.bulkInsert (/Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/orama-manager.js:84:52)
    at OramaManager.afterCollectionCreationOrUpdate (/Users/giogaspa/Projects/Orama/orama-strapi-4-playground/node_modules/@oramacloud/plugin-strapi/server/services/orama-manager.js:166:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.14.0
```

This is the modal where you can set the collection:

![image](https://github.com/user-attachments/assets/b32d731a-72b4-42a9-b7ac-2b3b80537782)
